### PR TITLE
Add RabbitMQ consumer and doc_intelligence workflow

### DIFF
--- a/.github/workflows/dockerx-doc-intelligence.yml
+++ b/.github/workflows/dockerx-doc-intelligence.yml
@@ -1,0 +1,51 @@
+name: Docker Build Image-docIntelligence
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clean up unnecessary large folders
+      run: |
+        # Delete unnecessary large folders
+        sudo rm -rf /opt/hostedtoolcache
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/share/boost
+        # Clean apt cache
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
+        # Show available disk space
+        df -h
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        buildkitd-flags: --debug
+
+    - name: Login to Aliyun Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ secrets.DOCKER_REGISTRY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: ./docker/global
+        file: ./docker/global/Dockerfile
+        push: true
+        tags: ${{ secrets.DOCKER_REGISTRY }}/${{secrets.DOCKER_NAMESPACE}}/doc_intelligence:latest
+        cache-from: type=registry,ref=${{ secrets.DOCKER_REGISTRY }}/${{secrets.DOCKER_NAMESPACE}}/doc_intelligence:buildcache
+        cache-to: type=registry,ref=${{ secrets.DOCKER_REGISTRY }}/${{secrets.DOCKER_NAMESPACE}}/doc_intelligence:buildcache,mode=max

--- a/projects/web_api/README.md
+++ b/projects/web_api/README.md
@@ -29,3 +29,14 @@ docker run --rm -it --gpus=all -p 8000:8000 mineru-api
 http://localhost:8000/docs
 http://127.0.0.1:8000/docs
 ```
+
+## RabbitMQ消费者
+
+使用 `rabbitmq_consumer.py` 可以从 RabbitMQ 队列读取待解析文件路径并生成解析结果，示例：
+```bash
+export RABBITMQ_HOST=localhost
+export RABBITMQ_QUEUE=parse_queue
+python rabbitmq_consumer.py
+```
+
+消息体需为 JSON 格式，至少包含 `file_path` 字段。

--- a/projects/web_api/rabbitmq_consumer.py
+++ b/projects/web_api/rabbitmq_consumer.py
@@ -1,0 +1,63 @@
+import json
+import os
+
+import pika
+
+from app import init_writers, process_file
+
+
+def handle_message(ch, method, properties, body):
+    try:
+        message = json.loads(body)
+        file_path = message.get("file_path")
+        parse_method = message.get("parse_method", "auto")
+        output_dir = message.get("output_dir", "output")
+        if not file_path:
+            raise ValueError("`file_path` is required")
+
+        file_name = os.path.basename(file_path).split(".")[0]
+        output_path = os.path.join(output_dir, file_name)
+        output_image_path = os.path.join(output_path, "images")
+
+        writer, image_writer, file_bytes, file_extension = init_writers(
+            file_path=file_path,
+            file=None,
+            output_path=output_path,
+            output_image_path=output_image_path,
+        )
+
+        infer_result, pipe_result = process_file(
+            file_bytes, file_extension, parse_method, image_writer
+        )
+
+        pipe_result.dump_md(writer, f"{file_name}.md", "images")
+        pipe_result.dump_content_list(writer, f"{file_name}_content_list.json", "images")
+        pipe_result.dump_middle_json(writer, f"{file_name}_middle.json")
+
+        ch.basic_ack(delivery_tag=method.delivery_tag)
+    except Exception as e:
+        print(f"Failed to process message {body!r}: {e}")
+        ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+
+
+def main():
+    host = os.getenv("RABBITMQ_HOST", "localhost")
+    queue = os.getenv("RABBITMQ_QUEUE", "parse_queue")
+
+    connection = pika.BlockingConnection(pika.ConnectionParameters(host=host))
+    channel = connection.channel()
+    channel.queue_declare(queue=queue, durable=True)
+    channel.basic_qos(prefetch_count=1)
+    channel.basic_consume(queue=queue, on_message_callback=handle_message)
+
+    print(f" [*] Waiting for messages in '{queue}'. To exit press CTRL+C")
+    try:
+        channel.start_consuming()
+    except KeyboardInterrupt:
+        channel.stop_consuming()
+    finally:
+        connection.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/web_api/requirements.txt
+++ b/projects/web_api/requirements.txt
@@ -3,3 +3,4 @@ magic-pdf[full]
 fastapi
 uvicorn
 python-multipart
+pika>=1.3.2


### PR DESCRIPTION
## Summary
- add RabbitMQ consumer script for message-based parsing
- document consumer usage in the Web API README
- include pika dependency for RabbitMQ
- build doc_intelligence Docker image via new workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6843c9e5a8808325b438b0a16239ec3e